### PR TITLE
Fix makefile warnings

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -1,4 +1,3 @@
-MAKE	= make -r
 GCC		= gcc
 GPP		= g++
 LD		= ld
@@ -20,9 +19,6 @@ $(TARGET) : $(OBJS_TARGET) Makefile Makefile.in
 %.o : %.c Makefile Makefile.in
 	$(GCC) -c $(CFLAGS) -o $*.o $*.c
 	
-%.o : %.cpp Makefile Makefile.in
-	$(GPP) -c $(CFLAGS) -o $*.o $*.cpp
-
 # commands
 
 clean :

--- a/Makefile.in
+++ b/Makefile.in
@@ -22,4 +22,4 @@ $(TARGET) : $(OBJS_TARGET) Makefile Makefile.in
 # commands
 
 clean :
-	-$(RM) *.o
+	-$(RM) -f *.o $(TARGET)


### PR DESCRIPTION
- BSD make でも動くように修正
- make clean で -f を指定してエラーを抑制
- make clean で ${TARGET} の nanotodon バイナリも削除