### PR TITLE
Fix printf format strings

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -1,4 +1,3 @@
-MAKE	= make -r
 GCC		= gcc
 GPP		= g++
 LD		= ld
@@ -20,10 +19,7 @@ $(TARGET) : $(OBJS_TARGET) Makefile Makefile.in
 %.o : %.c Makefile Makefile.in
 	$(GCC) -c $(CFLAGS) -o $*.o $*.c
 	
-%.o : %.cpp Makefile Makefile.in
-	$(GPP) -c $(CFLAGS) -o $*.o $*.cpp
-
 # commands
 
 clean :
-	-$(RM) *.o
+	-$(RM) -f *.o $(TARGET)

--- a/nanotodon.c
+++ b/nanotodon.c
@@ -471,7 +471,7 @@ void do_create_client(char *domain)
 void do_oauth(char *code, char *ck, char *cs)
 {
 	char fields[512];
-	sprintf(fields, "client_id=%s&client_secret=%s&grant_type=authorization_code&code=%s&scope=read%20write%20follow", ck, cs, code);
+	sprintf(fields, "client_id=%s&client_secret=%s&grant_type=authorization_code&code=%s&scope=read%%20write%%20follow", ck, cs, code);
 	
 	FILE *f = fopen(".nanotter", "wb");
 	


### PR DESCRIPTION
以下の警告の修正:
```
nanotodon.c: In function 'do_oauth':
nanotodon.c:512:18: warning: unknown conversion type character 'w' in format [-Wformat=]
  sprintf(fields, "client_id=%s&client_secret=%s&grant_type=authorization_code&code=%s&scope=read%20write%20follow", ck, cs, code);
                  ^
nanotodon.c:512:18: warning: format '%f' expects a matching 'double' argument [-Wformat=]
nanotodon.c:512:18: warning: unknown conversion type character 'w' in format [-Wformat=]
nanotodon.c:512:18: warning: format '%f' expects a matching 'double' argument [-Wformat=]
```
この認証URLが実際に使われているのかどうかは確認してません。