### PR TITLE
Fix unused variable warnings.

### DIFF
--- a/nanotodon.c
+++ b/nanotodon.c
@@ -626,7 +626,7 @@ void do_htl(void)
 			
 			stream_event_update(obj);
 			
-			char *p = strdup(json_object_to_json_string(obj));
+			//char *p = strdup(json_object_to_json_string(obj));
 			
 			//FILE *fp = fopen("rest_json.log","wt");
 			//fputs(p, fp);
@@ -656,7 +656,6 @@ int main(int argc, char *argv[])
 		fclose(f2);
 	} else {
 		char domain[256];
-		char key[256];
 		char *ck;
 		char *cs;
 		printf("はじめまして！ようこそnaotodonへ!\n");


### PR DESCRIPTION
以下の警告の修正です
```
nanotodon.c: In function 'do_htl':
nanotodon.c:629:10: warning: unused variable 'p' [-Wunused-variable]
    char *p = strdup(json_object_to_json_string(obj));
          ^
nanotodon.c: In function 'main':
nanotodon.c:659:8: warning: unused variable 'key' [-Wunused-variable]
   char key[256];
```