### PR TITLE
Minor fix for LIBS.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,6 @@ OBJS_TARGET	= nanotodon.o
 
 CFLAGS = -g
 LDFLAGS = 
-LIBS = -lc -lm -lcurl -ljson-c -lncursesw -lpthread
+LIBS = -lcurl -ljson-c -lncursesw -lpthread -lm 
 
 include Makefile.in


### PR DESCRIPTION
ライブラリの指定について、以下のマイナーな修正です
* -lc は標準でリンクされるので指定不要では
* -lm はシステム標準ライブラリなので最後にしたい
(仮に他のオプションのライブラリが libm 関数を使用していた場合、かつ、 static link の場合は順序依存があるのでリンクに失敗する)