### PR TITLE
設定のディレクトリ化とXDG Base Directoryサポート

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 TARGET		= nanotodon
 OBJS_TARGET	= nanotodon.o config.o
 
-CFLAGS = -g
+CFLAGS = -g -DSUPPORT_XDG_BASE_DIR
 LDFLAGS = 
 LIBS = -lc -lm -lcurl -ljson-c -lncursesw -lpthread
 

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 TARGET		= nanotodon
-OBJS_TARGET	= nanotodon.o
+OBJS_TARGET	= nanotodon.o config.o
 
 CFLAGS = -g
 LDFLAGS = 

--- a/config.c
+++ b/config.c
@@ -26,7 +26,7 @@ static int init_xdg(struct nanotodon_config *config, const char* xdg_config_home
 	return 1;
 }
 
-int nano_init_config(struct nanotodon_config *config)
+int nano_config_init(struct nanotodon_config *config)
 {
 	char *homepath = getenv("HOME");
 
@@ -58,7 +58,7 @@ makepath:
 	return 1;
 }
 
-int nano_app_token_filename(struct nanotodon_config *config, const char* domain, char *buf, size_t buf_length)
+int nano_config_app_token_filename(struct nanotodon_config *config, const char* domain, char *buf, size_t buf_length)
 {
 	char app_token_dir[256];
 	snprintf(app_token_dir, sizeof(app_token_dir), "%s/app_token", config->root_dir);

--- a/config.c
+++ b/config.c
@@ -4,38 +4,64 @@
 #include <errno.h>
 #include "config.h"
 
-static int mkdir_or_die(const char* path);
+#define MAKE_CONFIG_DIR_OK 0x00
+#define MAKE_CONFIG_DIR_CANT_CREATE 0x01
+#define MAKE_CONFIG_DIR_FILE_EXISTS 0x02
+
+static int make_config_dir(const char* path);
+static void make_config_dir_or_die(const char* path);
 static int init_xdg(struct nanotodon_config *config, const char* xdg_config_home);
 
-static int mkdir_or_die(const char* path)
+static int make_config_dir(const char* path)
 {
 	// existence check
 	struct stat st;
 	if (stat(path, &st) == 0) {
 		if ((st.st_mode & S_IFMT) == S_IFDIR) {
-			return 1;
+			return MAKE_CONFIG_DIR_OK;
 		}
 
 		// exists other entry
-		fprintf(stderr, "FATAL: File already exists '%s'\n", path);
-		exit(EXIT_FAILURE);
+		return MAKE_CONFIG_DIR_FILE_EXISTS;
 	}
 
 	if (errno == ENOENT && mkdir(path, 0755) == 0) {
-		return 1;
+		return MAKE_CONFIG_DIR_OK;
 	}
 
-	fprintf(stderr, "FATAL: Can't create directory '%s' (errno=%d)\n", path, errno);
-	exit(EXIT_FAILURE);
+	return MAKE_CONFIG_DIR_CANT_CREATE;
+}
+
+static void make_config_dir_or_die(const char* path)
+{
+	int result = make_config_dir(path);
+
+	switch (result)
+	{
+	case MAKE_CONFIG_DIR_OK:
+		return;
+	case MAKE_CONFIG_DIR_CANT_CREATE:
+		fprintf(stderr, "FATAL: Can't create directory '%s' (errno=%d)\n", path, errno);
+		exit(EXIT_FAILURE);
+	case MAKE_CONFIG_DIR_FILE_EXISTS:
+		fprintf(stderr, "FATAL: File already exists '%s'\n", path);
+		exit(EXIT_FAILURE);
+	default:
+		fprintf(stderr, "FATAL: Undefined error (errno=%d)\n", errno);
+		exit(EXIT_FAILURE);
+	}
 }
 
 static int init_xdg(struct nanotodon_config *config, const char* xdg_config_home)
 {
 	// make xdg config home
-	mkdir_or_die(xdg_config_home);
-	sprintf(config->root_dir, "%s/nanotodon", xdg_config_home);
+	int make_home_result = make_config_dir(xdg_config_home);
+	if (make_home_result != MAKE_CONFIG_DIR_OK) {
+		return make_home_result;
+	}
 
-	return 1;
+	sprintf(config->root_dir, "%s/nanotodon", xdg_config_home);
+	return make_config_dir(config->root_dir);
 }
 
 int nano_config_init(struct nanotodon_config *config)
@@ -45,29 +71,23 @@ int nano_config_init(struct nanotodon_config *config)
 	// TODO: マクロでXDG Base Directory使うか切り替えてもよさそう
 	// XDG_CONFIG_HOME
 	char *xdg_config_home = getenv("XDG_CONFIG_HOME");
-	if (xdg_config_home != NULL) {
-		if (init_xdg(config, xdg_config_home)) {
-			goto makepath;
-		} else {
-			return 0;
-		}
+	if (xdg_config_home != NULL && init_xdg(config, xdg_config_home) == MAKE_CONFIG_DIR_OK) {
+		goto makepath;
 	}
 
 	// $HOME/.config
 	char default_xdg_config_home[256];
 	sprintf(default_xdg_config_home, "%s/.config", homepath);
-	if (init_xdg(config, default_xdg_config_home)) {
+	if (init_xdg(config, default_xdg_config_home) == MAKE_CONFIG_DIR_OK) {
 		goto makepath;
-	} else {
-		return 0;
 	}
 
 	// $HOME/.nanotodon
 	sprintf(config->root_dir, "%s/.nanotodon", homepath);
+	make_config_dir_or_die(config->root_dir);
 
 makepath:
 
-	mkdir_or_die(config->root_dir);
 	sprintf(config->dot_token, "%s/token", config->root_dir);
 	sprintf(config->dot_domain, "%s/domain", config->root_dir);
 
@@ -78,7 +98,7 @@ int nano_config_app_token_filename(struct nanotodon_config *config, const char* 
 {
 	char app_token_dir[256];
 	snprintf(app_token_dir, sizeof(app_token_dir), "%s/app_token", config->root_dir);
-	mkdir_or_die(app_token_dir);
+	make_config_dir_or_die(app_token_dir);
 
 	return snprintf(buf, buf_length, "%s/%s", app_token_dir, domain);
 }

--- a/config.c
+++ b/config.c
@@ -1,5 +1,6 @@
 #include <stdio.h>
 #include <stdlib.h>
+#include <string.h>
 #include <sys/stat.h>
 #include <errno.h>
 #include "config.h"
@@ -41,13 +42,13 @@ static void make_config_dir_or_die(const char* path)
 	case MAKE_CONFIG_DIR_OK:
 		return;
 	case MAKE_CONFIG_DIR_CANT_CREATE:
-		fprintf(stderr, "FATAL: Can't create directory '%s' (errno=%d)\n", path, errno);
+		fprintf(stderr, "FATAL: Can't create directory '%s' (%s)\n", path, strerror(errno));
 		exit(EXIT_FAILURE);
 	case MAKE_CONFIG_DIR_FILE_EXISTS:
 		fprintf(stderr, "FATAL: File already exists '%s'\n", path);
 		exit(EXIT_FAILURE);
 	default:
-		fprintf(stderr, "FATAL: Undefined error (errno=%d)\n", errno);
+		fprintf(stderr, "FATAL: Undefined error (%s)\n", strerror(errno));
 		exit(EXIT_FAILURE);
 	}
 }

--- a/config.c
+++ b/config.c
@@ -13,7 +13,10 @@
 
 static int make_config_dir(const char* path);
 static void make_config_dir_or_die(const char* path);
+
+#ifdef SUPPORT_XDG_BASE_DIR
 static int init_xdg(struct nanotodon_config *config, const char* xdg_config_home);
+#endif
 
 static int make_config_dir(const char* path)
 {
@@ -55,6 +58,7 @@ static void make_config_dir_or_die(const char* path)
 	}
 }
 
+#ifdef SUPPORT_XDG_BASE_DIR
 static int init_xdg(struct nanotodon_config *config, const char* xdg_config_home)
 {
 	// make xdg config home
@@ -69,12 +73,13 @@ static int init_xdg(struct nanotodon_config *config, const char* xdg_config_home
 	}
 	return make_config_dir(config->root_dir);
 }
+#endif
 
 int nano_config_init(struct nanotodon_config *config)
 {
 	char *homepath = getenv("HOME");
 
-	// TODO: マクロでXDG Base Directory使うか切り替えてもよさそう
+#ifdef SUPPORT_XDG_BASE_DIR
 	// XDG_CONFIG_HOME
 	char *xdg_config_home = getenv("XDG_CONFIG_HOME");
 	if (xdg_config_home != NULL && init_xdg(config, xdg_config_home) == MAKE_CONFIG_DIR_OK) {
@@ -89,6 +94,7 @@ int nano_config_init(struct nanotodon_config *config)
 	if (init_xdg(config, default_xdg_config_home) == MAKE_CONFIG_DIR_OK) {
 		goto makepath;
 	}
+#endif
 
 	// $HOME/.nanotodon
 	if (snprintf(config->root_dir, sizeof(config->root_dir), "%s/.nanotodon", homepath) >= sizeof(config->root_dir)) {

--- a/config.c
+++ b/config.c
@@ -1,0 +1,70 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <sys/stat.h>
+#include "config.h"
+
+static int exists_dir(const char* path)
+{
+	struct stat st;
+	int ret = stat(path, &st);
+	if (ret == 0 && (st.st_mode & S_IFMT) == S_IFDIR) {
+		return 1;
+	} else {
+		return 0;
+	}
+}
+
+static int init_xdg(struct nanotodon_config *config, const char* xdg_config_home)
+{
+	// make xdg config home
+	if (!exists_dir(xdg_config_home) && mkdir(xdg_config_home, 0755)) {
+		return 0;
+	}
+
+	sprintf(config->root_dir, "%s/nanotodon", xdg_config_home);
+
+	return 1;
+}
+
+int nano_init_config(struct nanotodon_config *config)
+{
+	char *homepath = getenv("HOME");
+
+	// TODO: マクロでXDG Base Directory使うか切り替えてもよさそう
+	// XDG_CONFIG_HOME
+	char *xdg_config_home = getenv("XDG_CONFIG_HOME");
+	if (xdg_config_home != NULL && init_xdg(config, xdg_config_home)) {
+		goto makepath;
+	}
+
+	// $HOME/.config
+	char default_xdg_config_home[256];
+	sprintf(default_xdg_config_home, "%s/.config", homepath);
+	if (init_xdg(config, default_xdg_config_home)) {
+		goto makepath;
+	}
+
+	// $HOME/.nanotodon
+	sprintf(config->root_dir, "%s/.nanotodon", homepath);
+
+makepath:
+
+	if (!exists_dir(config->root_dir) && mkdir(config->root_dir, 0755)) {
+		return 0;
+	}
+	sprintf(config->dot_token, "%s/token", config->root_dir);
+	sprintf(config->dot_domain, "%s/domain", config->root_dir);
+
+	return 1;
+}
+
+int nano_app_token_filename(struct nanotodon_config *config, const char* domain, char *buf, size_t buf_length)
+{
+	char app_token_dir[256];
+	snprintf(app_token_dir, sizeof(app_token_dir), "%s/app_token", config->root_dir);
+	if (!exists_dir(app_token_dir) && mkdir(app_token_dir, 0755)) {
+		return 0;
+	}
+
+	return snprintf(buf, buf_length, "%s/%s", app_token_dir, domain);
+}

--- a/config.c
+++ b/config.c
@@ -115,7 +115,7 @@ buffer_err:
 
 int nano_config_app_token_filename(struct nanotodon_config *config, const char* domain, char *buf, size_t buf_length)
 {
-	const unsigned int path_length = strlen(config->root_dir) + strlen(APP_TOKEN_DIR) + 1 + strlen(domain);
+	const size_t path_length = strlen(config->root_dir) + strlen(APP_TOKEN_DIR) + 1 + strlen(domain);
 	if (path_length >= buf_length) {
 		// 予測パス長がバッファに収まりきらない場合は、何もしないで予測パス長を返す
 		return path_length;

--- a/config.c
+++ b/config.c
@@ -3,6 +3,9 @@
 #include <sys/stat.h>
 #include "config.h"
 
+static int exists_dir(const char* path);
+static int init_xdg(struct nanotodon_config *config, const char* xdg_config_home);
+
 static int exists_dir(const char* path)
 {
 	struct stat st;

--- a/config.h
+++ b/config.h
@@ -9,8 +9,8 @@ struct nanotodon_config {
 	char dot_domain[256];
 };
 
-int nano_init_config(struct nanotodon_config *config);
+int nano_config_init(struct nanotodon_config *config);
 
-int nano_app_token_filename(struct nanotodon_config *config, const char* domain, char *buf, size_t buf_length);
+int nano_config_app_token_filename(struct nanotodon_config *config, const char* domain, char *buf, size_t buf_length);
 
 #endif

--- a/config.h
+++ b/config.h
@@ -1,0 +1,16 @@
+#ifndef NANOTODON_CONFIG_H
+#define NANOTODON_CONFIG_H
+
+#include <stdlib.h>
+
+struct nanotodon_config {
+	char root_dir[256];
+	char dot_token[256];
+	char dot_domain[256];
+};
+
+int nano_init_config(struct nanotodon_config *config);
+
+int nano_app_token_filename(struct nanotodon_config *config, const char* domain, char *buf, size_t buf_length);
+
+#endif

--- a/nanotodon.c
+++ b/nanotodon.c
@@ -727,7 +727,10 @@ retry1:
 		fclose(f2);
 
 		char dot_ckcs[256];
-		nano_config_app_token_filename(&config, domain, dot_ckcs, sizeof(dot_ckcs));
+		if (nano_config_app_token_filename(&config, domain, dot_ckcs, sizeof(dot_ckcs)) >= sizeof(dot_ckcs)) {
+			fprintf(stderr, "FATAL: Can't allocate memory. Too long filename.\n");
+			exit(EXIT_FAILURE);
+		}
 		
 		char json_name[256];
 		strcpy(json_name, dot_ckcs);

--- a/nanotodon.c
+++ b/nanotodon.c
@@ -698,7 +698,7 @@ void do_htl(void)
 
 int main(int argc, char *argv[])
 {
-	nano_init_config(&config);
+	nano_config_init(&config);
     
 	FILE *fp = fopen(config.dot_token, "rb");
 	if(fp) {
@@ -727,7 +727,7 @@ retry1:
 		fclose(f2);
 
 		char dot_ckcs[256];
-		nano_app_token_filename(&config, domain, dot_ckcs, sizeof(dot_ckcs));
+		nano_config_app_token_filename(&config, domain, dot_ckcs, sizeof(dot_ckcs));
 		
 		char json_name[256];
 		strcpy(json_name, dot_ckcs);

--- a/nanotodon.c
+++ b/nanotodon.c
@@ -10,6 +10,7 @@
 #include <curses.h>
 #include <ncurses.h>
 #include <pthread.h>
+#include "config.h"
 
 char *streaming_json = NULL;
 
@@ -26,7 +27,7 @@ WINDOW *pad;
 char access_token[256];
 char domain_string[256];
 
-char dot_domain[256], dot_token[256], dot_ckcs[256];
+struct nanotodon_config config;
 
 int term_w, term_h;
 int pad_x = 0, pad_y = 0;
@@ -471,7 +472,7 @@ int insert_chars(STB_TEXTEDIT_STRING *str, int pos, STB_TEXTEDIT_CHARTYPE *newte
 #define STB_TEXTEDIT_IMPLEMENTATION
 #include "stb_textedit.h"
 
-void do_create_client(char *domain)
+void do_create_client(char *domain, char *dot_ckcs)
 {
 	CURLcode ret;
 	CURL *hnd;
@@ -526,7 +527,7 @@ void do_oauth(char *code, char *ck, char *cs)
 	char fields[512];
 	sprintf(fields, "client_id=%s&client_secret=%s&grant_type=authorization_code&code=%s&scope=read%%20write%%20follow", ck, cs, code);
 	
-	FILE *f = fopen(dot_token, "wb");
+	FILE *f = fopen(config.dot_token, "wb");
 	
 	CURLcode ret;
 	CURL *hnd;
@@ -697,19 +698,16 @@ void do_htl(void)
 
 int main(int argc, char *argv[])
 {
-	char *homepath = getenv("HOME");
-	
-	sprintf(dot_token, "%s/.nanotodon_token", homepath);
-	sprintf(dot_domain, "%s/.nanotodon_domain", homepath);
-	
-	FILE *fp = fopen(dot_token, "rb");
+	nano_init_config(&config);
+    
+	FILE *fp = fopen(config.dot_token, "rb");
 	if(fp) {
 		fclose(fp);
 		struct json_object *token;
-		struct json_object *jobj_from_file = json_object_from_file(dot_token);
+		struct json_object *jobj_from_file = json_object_from_file(config.dot_token);
 		read_json_fom_path(jobj_from_file, "access_token", &token);
 		sprintf(access_token, "Authorization: Bearer %s", json_object_get_string(token));
-		FILE *f2 = fopen(dot_domain, "rb");
+		FILE *f2 = fopen(config.dot_domain, "rb");
 		fscanf(f2, "%255s", domain_string);
 		fclose(f2);
 	} else {
@@ -724,18 +722,19 @@ retry1:
 		scanf("%255s", domain);
 		printf("\n");
 		
-		FILE *f2 = fopen(dot_domain, "wb");
+		FILE *f2 = fopen(config.dot_domain, "wb");
 		fprintf(f2, "%s", domain);
 		fclose(f2);
-		
-		sprintf(dot_ckcs, "%s/.nanotodon_%s.ckcs", homepath, domain);
+
+		char dot_ckcs[256];
+		nano_app_token_filename(&config, domain, dot_ckcs, sizeof(dot_ckcs));
 		
 		char json_name[256];
 		strcpy(json_name, dot_ckcs);
 		strcpy(domain_string, domain);
 		FILE *ckcs = fopen(json_name, "rb");
 		if(!ckcs) {
-			do_create_client(domain);
+			do_create_client(domain, dot_ckcs);
 		} else {
 			fclose(ckcs);
 		}
@@ -747,7 +746,7 @@ retry1:
 		if(!r1 || !r2) {
 			printf("何かがおかしいみたいだよ。\nもう一度やり直すね。");
 			remove(json_name);
-			remove(dot_domain);
+			remove(config.dot_domain);
 			goto retry1;
 		}
 		ck = strdup(json_object_get_string(cko));
@@ -763,13 +762,13 @@ retry1:
 		printf("\n");
 		do_oauth(code, ck, cs);
 		struct json_object *token;
-		jobj_from_file = json_object_from_file(dot_token);
+		jobj_from_file = json_object_from_file(config.dot_token);
 		int r3 = read_json_fom_path(jobj_from_file, "access_token", &token);
 		if(!r3) {
 			printf("何かがおかしいみたいだよ。\n入力したコードはあっているかな？\nもう一度やり直すね。");
 			remove(json_name);
-			remove(dot_domain);
-			remove(dot_token);
+			remove(config.dot_domain);
+			remove(config.dot_token);
 			goto retry1;
 		}
 		sprintf(access_token, "Authorization: Bearer %s", json_object_get_string(token));


### PR DESCRIPTION
設定ファイルが$HOME直下にぶちまけられて鬱病になりそうだったので、サブディレクトリを作成するような対応を入れました。

ついでに、XDG Base Directory準拠っぽく作成するようにしてありますが、これは好みの問題もありそうなのでmake時の定数や環境変数なんかで切り替えられる形にするのも良いかもしれませんね。