### PR TITLE
Use proper default target for make(1).

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -6,8 +6,7 @@ CP		= cp
 
 # default
 
-default :
-	$(MAKE) $(TARGET)
+default : $(TARGET)
 
 # rules
 


### PR DESCRIPTION
現状だと `Makefile.in` の `default` のターゲットで `${MAKE}` を再帰で呼んでいますが、
この再帰で呼ばれる `${MAKE}` には元の `make` 呼び出しで指定された `-f Makefile.bsd` 等の引数が反映されないので
include 元の `Makefile.bsd` にある `CFLAGS` 等が反映されません。
ターゲットとして `nanotodon` を明示的に指定すれば `${MAKE}` が起動されないので動きますが。

```
% make -f Makefile.bsd
make nanotodon
cc -g -DSUPPORT_XDG_BASE_DIR   -c nanotodon.c
nanotodon.c:1:10: fatal error: curl/curl.h: No such file or directory
 #include <curl/curl.h>
          ^~~~~~~~~~~~~
compilation terminated.
*** Error code 1

Stop.
make[1]: stopped in /s/tsutsui/nanotodon
*** Error code 1

Stop.
make: stopped in /s/tsutsui/nanotodon
% make -f Makefile.bsd nanotodon
cc -g -DSUPPORT_XDG_BASE_DIR -I/usr/pkg/include -I/usr/pkg/include/ncursesw -DNCURSES_WIDECHAR   -c nanotodon.c
cc -g -DSUPPORT_XDG_BASE_DIR -I/usr/pkg/include -I/usr/pkg/include/ncursesw -DNCURSES_WIDECHAR   -c config.c
cc -g -DSUPPORT_XDG_BASE_DIR -I/usr/pkg/include -I/usr/pkg/include/ncursesw -DNCURSES_WIDECHAR   -c messages.c
gcc nanotodon.o config.o messages.o  -L/usr/pkg/lib -Wl,-R/usr/pkg/lib -lcurl -lpthread -lm -lncursesw -o nanotodon
% 
```