### PR TITLE
Handle encoded apostrophe in toots properly.

### DIFF
--- a/nanotodon.c
+++ b/nanotodon.c
@@ -412,6 +412,10 @@ void stream_event_update(struct sjson_node *jobj_from_string)
 					waddch(scr, '\'');
 					src += 5;
 				}
+				else if(strncmp(src, "&#39;", 5) == 0) {
+					waddch(scr, '\'');
+					src += 4;
+				}
 			} else {
 				// 通常文字
 				waddch(scr, *((unsigned char *)src));


### PR DESCRIPTION
#23 の問題について
mikutter に json をコピーするプラグインが入ってたなあ、と思って当該トゥートの中身を確認したら
```
"content":"<p>nanotodon の件を忘れたままやなテスト &#39;&#39;&#39;</p>"
```
という感じだったので雑に置換してみました。
`&#xx;` を汎用で処理すべきかもしれませんが……