### PR TITLE
Fix offset character count for /private command (and Typo)

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ TUI/C99 Mastodon Client
 ```make```
 
 ## If your package manager don't have ncursesw (when ncursesw is combined in ncurses package)
-```make NCURSES=ncurces```
+```make NCURSES=ncurses```
 
 # Options
 

--- a/nanotodon.c
+++ b/nanotodon.c
@@ -785,7 +785,7 @@ void do_toot(char *s)
 				s++;
 			} else if(strncmp(s+1,"private",7) == 0) {
 				is_locked = 1;
-				s += 1+4;
+				s += 1+7;
 			} else if(strncmp(s+1,"unlisted",8) == 0) {
 				is_unlisted = 1;
 				s += 1+8;


### PR DESCRIPTION
おそらく `/lock` -> `/private` に変えた時にオフセットが変わってなくて、余計な文字列も一緒に投稿されちゃうので修正です。
それと、README.md に typo っぽいものがあったので一緒に修正してあります。