### PR TITLE
Avoid discard const warnings.

### DIFF
--- a/sbuf.c
+++ b/sbuf.c
@@ -22,7 +22,7 @@ void nflushcache(sbctx_t *sbctx)
 }
 
 // バッファへ追記
-void nputbuf(sbctx_t *sbctx, void *d, int l)
+void nputbuf(sbctx_t *sbctx, const void *d, int l)
 {
 	// l > n * SBCTX_CACHESIZE (n > 1) でも勝手に再帰してくれる
 	if(l > SBCTX_CACHESIZE) {
@@ -97,7 +97,7 @@ void naddch(sbctx_t *sbctx, int c)
 }
 
 // 文字列出力
-void naddstr(sbctx_t *sbctx, char *s)
+void naddstr(sbctx_t *sbctx, const char *s)
 {
 	//waddstr(sbctx, s);
 	nputbuf(sbctx, s, strlen(s));

--- a/sbuf.h
+++ b/sbuf.h
@@ -14,10 +14,10 @@ typedef struct {
 
 void ninitbuf(sbctx_t *sbctx);
 void nflushcache(sbctx_t *sbctx);
-void nputbuf(sbctx_t *sbctx, void *d, int l);
+void nputbuf(sbctx_t *sbctx, const void *d, int l);
 void nattron(sbctx_t *sbctx, int n);
 void nattroff(sbctx_t *sbctx, int n);
 void naddch(sbctx_t *sbctx, int c);
-void naddstr(sbctx_t *sbctx, char *s);
+void naddstr(sbctx_t *sbctx, const char *s);
 
 #endif


### PR DESCRIPTION
この類の警告抑止
```
nanotodon.c:134:18: warning: passing argument 2 of ‘naddstr’ discards ‘const ’ qualifier from pointer target type [-Wdiscarded-qualifiers]
  134 |   naddstr(sbctx, dname);
      |                  ^~~~~
In file included from nanotodon.c:17:
sbuf.h:21:36: note: expected ‘char *’ but argument is of type ‘const char *’
   21 | void naddstr(sbctx_t *sbctx, char *s);
      |                              ~~~~~~^
```

ファイル末尾改行漏れも合わせて直しています（というかエディタが勝手に直した）