### PR TITLE
Remove _BSD_SOURCE for OpenBSD and _NETBSD_SOURCE for NetBSD.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ TARGET = nanotodon
 OBJS = nanotodon.o sbuf.o squeue.o sixel.o utils.o config.o messages.o
 
 # To use both XPG4 strptime(3) and GNU timegm(3)
-CFLAGS += -D_GNU_SOURCE -D_BSD_SOURCE -D_NETBSD_SOURCE
+CFLAGS += -D_GNU_SOURCE
 
 LDLIBS += -lcurl -lpthread -lm
 


### PR DESCRIPTION
Both NetBSD and OpenBSD don't require these unless any strict definitions like _POSIX_C_SOURCE and _XOPEN_SOURCE etc. are specified.

---

もともと今の定義は私が適当に提案したという問題がありますが、
CIをかけるならば本質的な警告が紛れないように余計な警告は消したい、となって、
OpenBSD と FreeBSD でも問題ないようなので投げておきます。

結論からすると、
GNU拡張の `timegm(3)` と XPG4 の `strptime(3)` を両方使うには glibc の場合に `_GNU_SOURCE` だけ定義すれば良い
でいいかと。

* Linux (glibc2)
	* https://manpages.ubuntu.com/manpages/trusty/man7/feature_test_macros.7.html
	によれば
		* 何も定義しないと ANSI Cにない XPG4 の関数定義は有効にならない
		* `_XOPEN_SOURCE` 等を定義すると、定義された関数定義が有効になる
		（つまり定義が広くなる方向）
		* `_GNU_SOURCE` を定義するとなんでもありになる
		* `_BSD_SOURCE` は過去の「なんでもあり」相当だったが glib 2.20 以降では非推奨

* NetBSD
	* man が無いので https://github.com/NetBSD/src/blob/trunk/sys/sys/featuretest.h
	を見ると
		* 何も定義しないと `_NETBSD_SOURCE` が定義されたのと等価でなんでもありになる
		* `_XOPEN_SOURCE` 等を定義すると、定義された処理系の関数定義のみが有効になり、定義されていないものは使えなくなる
		（つまり定義が狭くなる方向）
		* `_XOPEN_SOURCE` が定義されていても GNU拡張の関数を使いたい場合は明示的に `_NETBSD_SOURCE` を追加で定義する必要がある

* OpenBSD 
	* man があるか見ていませんが
	https://github.com/openbsd/src/blob/master/sys/sys/cdefs.h
	を見ると
		* 書式は違うが `_BSD_SOURCE` になってる以外は NetBSDと同じ感じ
		* `_BSD_SOURCE` の出どころは調べてませんが 4.4BSD にはなさそう。386BSD から？

* FreeBSD
	* https://github.com/freebsd/freebsd-src/blob/main/sys/sys/cdefs.h を見ると
		* だいたい OpenBSD と同じだが `_BSD_SOURCE` や `_GNU_SOURCE` 相当の「明示的になんでもあり」の定義はなさそう 

`Makefile` で指定せずに `nanotodon.c` の中で `#ifdef __GNU_LIBRARY__` すればいいじゃん、
みたいな話もありますが、現状はソース内でのOS判定環境判定は無いようなので。