### PR TITLE
Display avatar icon and screen names etc. as one line header.

### DIFF
--- a/nanotodon.c
+++ b/nanotodon.c
@@ -248,6 +248,9 @@ void stream_event_update(struct sjson_node *jobj_from_string)
 
 	print_picture(sbctx_avt, avatar->string_, SIXEL_MUL_ICO);
 
+	// アイコン右側にカーソル移動
+	move_cursor_to_avatar(sbctx_avt);
+
 	nflushcache(&sb_avt);
 	squeue_enqueue(sb_avt);
 	//naddstr(sbctx, "\n");

--- a/sixel.h
+++ b/sixel.h
@@ -7,6 +7,7 @@
 #define SIXEL_MUL_ICO 8
 
 void print_picture(sbctx_t *sbctx, char *uri, int mul);
+void move_cursor_to_avatar(sbctx_t *sbctx);
 void sixel_init(void);
 
 #endif


### PR DESCRIPTION
rc3 の後に入れる変更じゃないという話もありますが、雑に書いたら動いているっぽいのでとりあえず投げておきます。

# 要件
* アバターアイコンサイズを「フォントの高さの2倍以上3倍未満でsixel単位の6ドットの倍数」にする (sayaka準拠)
* アバターアイコン表示の後、アイコンの次の行ではなくアイコンの右側に screen name, display name, date/time を表示する

# 実装設計
* 起動時の初期化  (`sixel_init()`)で以下を算出
	* `TIOCGWINSZ` の `ioctl(2)` で「画面の縦横ピクセル数」と「画面の縦横の行数・桁数」を取得して、それからフォントサイズを算出 (ロジックは sayaka さんから拝借)
	* `TIOCGWINSZ` が失敗したらデフォルトサイズを 7x14 にする (これもsayakaさんから拝借)
	* アイコンサイズとフォント幅から「screen name他のヘッダ相当行の先頭を右に何文字分動かすか」を算出
* トゥート表示 (`stream_event_update()`) のアイコン表示後の動作を以下の通り変更
	* カーソルを1行上に移動
	* カーソルをアイコン幅相当文字数分だけ右に移動
	* そのまま screen name, display name, date/time 他を表示
		* screen name (display name) と date/time で2行に分ける、というのもやってみましたがなんかいまいちでした 
* `print_picture()` を以下の通り変更
	*  `mul` 引数の解釈を適当にいじって算出したアイコンサイズで表示するように修正

# 要検討項目
いずれもAPI変更になるのでここではいじってません。
* `print_picture()` の `mul` 引数の定義がもともと複数の意味を一つに詰め込んでいて読んで解釈しづらい
	* サイズ、種別、属性、の引数に分割するか、アイコンと画像で別の wrapper関数にしたほうが見通しが良いような気がする
* 「アイコン幅相当文字数」を算出側の `sixel.c` から参照側の `nanotodon.c` にグローバル変数で渡しているのがダサい
	* 「アイコン表示」の関数を別にして、返り値で右移動量を出す、とかのほうがスッキリしそう
* sayakaさん同様で「フォントサイズ指定オプション」もあったほうがよい？
	* 「sixel対応だけど `TIOCGWINSZ` 非対応」などというレアケースは考えなくていい？
* sayakaさん同様で、そもそも「端末がsixel対応しているか」のチェックを入れたほうが良い？
（今回の差分と関係ない）

あと `mlterm` と `mlterm-wscons` と `xterm -ti 382` しかテストしてないので、もう少しテストしたほうが良さそう。