### PR TITLE
CI: remove "usesh: true" to make sure ~/.profile is loaded.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -109,17 +109,12 @@ jobs:
         uses: vmactions/netbsd-vm@v1
         with:
           release: "10.0"
-          usesh: true
           copyback: false
           prepare: |
             uname -a
-            PATH=/bin:/sbin:/usr/bin:/usr/sbin:/usr/X11R7/bin:/usr/pkg/bin:/usr/pkg/sbin:/usr/games:/usr/local/bin:/usr/local/sbin
-            export PATH
             pkg_add -u curl libwebp
 
           run: |
-            PATH=/bin:/sbin:/usr/bin:/usr/sbin:/usr/X11R7/bin:/usr/pkg/bin:/usr/pkg/sbin:/usr/games:/usr/local/bin:/usr/local/sbin
-            export PATH
             echo Build default
             make clean
             CFLAGS="-I/usr/pkg/include" LDFLAGS="-L/usr/pkg/lib -Wl,-R/usr/pkg/lib" make
@@ -140,12 +135,9 @@ jobs:
         uses: vmactions/openbsd-vm@v1
         with:
           release: "7.5"
-          usesh: true
           copyback: false
           prepare: |
             uname -a
-            PATH=/bin:/sbin:/usr/bin:/usr/sbin:/usr/X11R6/bin:/usr/local/bin:/usr/local/sbin
-            export PATH
             pkg_add curl libwebp
 
           run: |
@@ -169,12 +161,9 @@ jobs:
         uses: vmactions/freebsd-vm@v1
         with:
           release: "14.0"
-          usesh: true
           copyback: false
           prepare: |
             uname -a
-            PATH=/bin:/sbin:/usr/bin:/usr/sbin:/usr/local/bin:/usr/local/sbin
-            export PATH
             pkg install -y curl webp
 
           run: |


### PR DESCRIPTION
nanotodon本体とは全く関係なく
https://github.com/isaki68k/sayaka/pull/40
と同じ netbsd-vm 他を使った CIの修正です。

> 今まで *BSDのCIで `PATH` が設定されないのはなぜなのだろうと思いつつ手動で書いていたのですが、
> いろいろ見ていたところ netbsd-vm 他の CIのオプション `usesh: true` を設定すると
> https://github.com/vmactions/netbsd-vm/blob/v1.0.8/run.sh
> の `execSSHSH()` で
> ```shell
> #using the sh 
> execSSHSH() {
>   exec ssh "$osname" sh
> }
> ```
> と `-t` 無しで `ssh` を呼んで `sh` を起動するので `~/.profile` が読まれていない、というオチでした。
> 
> そもそも NetBSD および FreeBSD 14.0 以降は root login shell が `/bin/sh` になっていること、
> OpenBSD は root login shell が `/bin/ksh` であるものの CIでは困らないので
> それぞれオプションを削除して `/root/.profile` にあるデフォルトパスが設定されるのも確認しました。