### PR TITLE
Update CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -42,9 +42,9 @@ jobs:
           echo Build with USE_SIXEL
           make clean
           CFLAGS="-DUSE_SIXEL" make
-          echo Build with USE_WEBP
+          echo Build with USE_SIXEL and USE_WEBP
           make clean
-          CFLAGS="-DUSE_WEBP" LDLIBS="-lwebp" make
+          CFLAGS="-DUSE_SIXEL -DUSE_WEBP" LDLIBS="-lwebp" make
 
   build-linux-qemu:
     name: "build-linux qemu"
@@ -95,9 +95,9 @@ jobs:
             echo Build with USE_SIXEL
             make clean
             CFLAGS="-DUSE_SIXEL" make
-            echo Build with USE_WEBP
+            echo Build with USE_SIXEL and USE_WEBP
             make clean
-            CFLAGS="-DUSE_WEBP" LDLIBS="-lwebp" make
+            CFLAGS="-DUSE_SIXEL -DUSE_WEBP" LDLIBS="-lwebp" make
 
   build-netbsd:
     name: "build-netbsd (NetBSD/amd64 10.0 with pkgsrc)"
@@ -121,9 +121,9 @@ jobs:
             echo Build with USE_SIXEL
             make clean
             CFLAGS="-I/usr/pkg/include -DUSE_SIXEL" LDFLAGS="-L/usr/pkg/lib -Wl,-R/usr/pkg/lib" make
-            echo Build with USE_WEBP
+            echo Build with USE_SIXEL and USE_WEBP
             make clean
-            CFLAGS="-I/usr/pkg/include -DUSE_WEBP" LDFLAGS="-L/usr/pkg/lib -Wl,-R/usr/pkg/lib" LDLIBS="-lwebp" make
+            CFLAGS="-I/usr/pkg/include -DUSE_SIXEL -DUSE_WEBP" LDFLAGS="-L/usr/pkg/lib -Wl,-R/usr/pkg/lib" LDLIBS="-lwebp" make
 
   build-openbsd:
     name: "build-openbsd (OpenBSD/amd64 7.6 with ports)"
@@ -147,9 +147,9 @@ jobs:
             echo Build with USE_SIXEL
             make clean
             CFLAGS="-I/usr/local/include -DUSE_SIXEL" LDFLAGS="-L/usr/local/lib" make
-            echo Build with USE_WEBP
+            echo Build with USE_SIXEL and USE_WEBP
             make clean
-            CFLAGS="-I/usr/local/include -DUSE_WEBP" LDFLAGS="-L/usr/local/lib" LDLIBS="-lwebp" make
+            CFLAGS="-I/usr/local/include -DUSE_SIXEL -DUSE_WEBP" LDFLAGS="-L/usr/local/lib" LDLIBS="-lwebp" make
 
   build-freesd:
     name: "build-freebsd (FreeBSD/amd64 14.1 with ports)"
@@ -173,6 +173,6 @@ jobs:
             echo Build with USE_SIXEL
             make clean
             CFLAGS="-I/usr/local/include -DUSE_SIXEL" LDFLAGS="-L/usr/local/lib" make
-            echo Build with USE_WEBP
+            echo Build with USE_SIXEL and USE_WEBP
             make clean
-            CFLAGS="-I/usr/local/include -DUSE_WEBP" LDFLAGS="-L/usr/local/lib" LDLIBS="-lwebp" make
+            CFLAGS="-I/usr/local/include -DUSE_SIXEL -DUSE_WEBP" LDFLAGS="-L/usr/local/lib" LDLIBS="-lwebp" make

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -126,7 +126,7 @@ jobs:
             CFLAGS="-I/usr/pkg/include -DUSE_WEBP" LDFLAGS="-L/usr/pkg/lib -Wl,-R/usr/pkg/lib" LDLIBS="-lwebp" make
 
   build-openbsd:
-    name: "build-openbsd (OpenBSD/amd64 7.5 with ports)"
+    name: "build-openbsd (OpenBSD/amd64 7.6 with ports)"
     runs-on: ubuntu-latest
 
     steps:
@@ -134,7 +134,7 @@ jobs:
       - name: Install packages and run configure and make (on the OpenBSD VM)
         uses: vmactions/openbsd-vm@v1
         with:
-          release: "7.5"
+          release: "7.6"
           copyback: false
           prepare: |
             uname -a
@@ -152,7 +152,7 @@ jobs:
             CFLAGS="-I/usr/local/include -DUSE_WEBP" LDFLAGS="-L/usr/local/lib" LDLIBS="-lwebp" make
 
   build-freesd:
-    name: "build-freebsd (FreeBSD/amd64 14.0 with ports)"
+    name: "build-freebsd (FreeBSD/amd64 14.1 with ports)"
     runs-on: ubuntu-latest
 
     steps:
@@ -160,7 +160,7 @@ jobs:
       - name: Install packages and run configure and make (on the FreeBSD VM)
         uses: vmactions/freebsd-vm@v1
         with:
-          release: "14.0"
+          release: "14.1"
           copyback: false
           prepare: |
             uname -a


### PR DESCRIPTION
`USE_WEBP` を `USE_SIXEL` なしで指定しても意味ないよな、と見てたら
OpenBSD 7.6 と FreeBSD 14.1 も出てるじゃん、ということでそちらも雑に更新しました。

つい先日の 12/3 に FreeBSD 14.2 が出てるっぽいですが、 [freebsd-vm](https://github.com/vmactions/freebsd-vm) の更新がまだなのでそちらは追って。