### PR TITLE
Appease -Wall warnings

### DIFF
--- a/sixel.c
+++ b/sixel.c
@@ -209,7 +209,7 @@ void print_picture(sbctx_t *sbctx, char *uri, int mul)
 
 	FILE *cfp;
 
-	if(cfp = fopen(cpath_buffer, "rb")) {
+	if((cfp = fopen(cpath_buffer, "rb")) != 0) {
 		//nputbuf(sbctx, "cache HIT!\n", 12);
 
 		int len;

--- a/sixel.c
+++ b/sixel.c
@@ -155,10 +155,10 @@ stbi_uc *webp_load_from_memory(stbi_uc const *buffer, int len, int *x, int *y, i
 }
 #endif
 
-unsigned int crc32b(unsigned char *message, int maxlen)
+uint32_t crc32b(const uint8_t *message, int maxlen)
 {
 	int i, j;
-	unsigned int byte, crc, mask;
+	uint32_t byte, crc, mask;
 
 	i = 0;
 	crc = 0xFFFFFFFF;
@@ -177,10 +177,11 @@ unsigned int crc32b(unsigned char *message, int maxlen)
 // outはchar[>17]であること
 void generate_hash(char *uri, char *out)
 {
-	int len = strlen(uri) >> 1;
+	const int len = strlen(uri) >> 1;
+	const uint8_t *uribytes = (uint8_t *)uri;
 
-	unsigned int hash1 = crc32b(uri, len);
-	unsigned int hash2 = crc32b(uri + len, len);
+	const uint32_t hash1 = crc32b(uribytes, len);
+	const uint32_t hash2 = crc32b(uribytes + len, len);
 
 	for(int i = 0; i < 4; i++) {
 		out[i*2+0] = "0123456789abcdef"[(hash1 >> (i * 8 + 0)) & 15];


### PR DESCRIPTION
FreeBSD と OpenBSD の CI結果見てたら警告出てたので適当に修正しました。
`crc32b()` のほうはつい気になって `const` 付加と `exact int type` を使う修正も入れてます。 (NetBSD盆栽病)

CRC32 を1ビットずつ計算すると遅マシンだと結構重いのでテーブルにしたほうが、
みたいな気もしますが、呼ばれる回数的に https 認証と比べたら大したこと誤差以下かも。