### PR TITLE
Style fixes

### DIFF
--- a/config.c
+++ b/config.c
@@ -11,11 +11,11 @@
 
 #define APP_TOKEN_DIR "/app_token"
 
-static int make_config_dir(const char* path);
-static void make_config_dir_or_die(const char* path);
+static int make_config_dir(const char *);
+static void make_config_dir_or_die(const char *);
 
 #ifdef SUPPORT_XDG_BASE_DIR
-static int init_xdg(struct nanotodon_config *config, const char* xdg_config_home, const char* xdg_config_cache);
+static int init_xdg(struct nanotodon_config *, const char *, const char *);
 #endif
 
 static int make_config_dir(const char* path)

--- a/config.h
+++ b/config.h
@@ -13,8 +13,8 @@ struct nanotodon_config {
 	char cache_dir[256];
 };
 
-int nano_config_init(struct nanotodon_config *config);
+int nano_config_init(struct nanotodon_config *);
 
-int nano_config_app_token_filename(struct nanotodon_config *config, const char* domain, char *buf, size_t buf_length);
+int nano_config_app_token_filename(struct nanotodon_config *, const char *, char *, size_t);
 
 #endif

--- a/nanotodon.c
+++ b/nanotodon.c
@@ -20,47 +20,47 @@
 #include "utils.h"
 #include "sixel.h"
 
-char *streaming_json = NULL;
+static char *streaming_json = NULL;
 
 #define URI_STREAM "api/v1/streaming/"
 #define URI_TIMELINE "api/v1/timelines/"
 
-char *selected_stream = "user";
-char *selected_timeline = "home";
-char append_timeline[64];
-int limit_timeline = 20;
+static const char *selected_stream = "user";
+static const char *selected_timeline = "home";
+static char append_timeline[64];
+static int limit_timeline = 20;
 
 #define CURL_USERAGENT "curl/" LIBCURL_VERSION
 
-pthread_mutex_t prompt_mutex;
-int prompt_notify = 0;
+static pthread_mutex_t prompt_mutex;
+static int prompt_notify = 0;
 
 // ストリーミングを受信する関数のポインタ
-void (*streaming_received_handler)(void);
+static void (*streaming_received_handler)(void);
 
 // 受信したストリーミングを処理する関数のポインタ
-void (*stream_event_handler)(struct sjson_node *);
+static void (*stream_event_handler)(struct sjson_node *);
 
 // インスタンスにクライアントを登録する
-void do_create_client(char *, char *);
+static void do_create_client(char *, char *);
 
 // Timelineの受信
-void get_timeline(void);
+static void get_timeline(void);
 
 // 承認コードを使ったOAuth処理
-void do_oauth(char *code, char *ck, char *cs);
+static void do_oauth(char *code, char *ck, char *cs);
 
 // Tootを行う
-void do_toot(char *);
+static void do_toot(char *);
 
 // ストリーミングでのToot受信処理,stream_event_handlerへ代入
-void stream_event_update(struct sjson_node *);
+static void stream_event_update(struct sjson_node *);
 
 // ストリーミングでの通知受信処理,stream_event_handlerへ代入
-void stream_event_notify(struct sjson_node *);
+static void stream_event_notify(struct sjson_node *);
 
 // アクセストークン文字列
-char access_token[256];
+static char access_token[256];
 
 // ドメイン文字列
 char domain_string[256];
@@ -69,8 +69,8 @@ char domain_string[256];
 struct nanotodon_config config;
 
 int monoflag = 0;
-int hidlckflag = 1;
-int noemojiflag = 0;
+static int hidlckflag = 1;
+static int noemojiflag = 0;
 
 // curlから呼び出されるストリーミング受信関数
 static size_t streaming_callback(void* ptr, size_t size, size_t nmemb, void* data) {
@@ -106,7 +106,7 @@ static size_t streaming_callback(void* ptr, size_t size, size_t nmemb, void* dat
 }
 
 // ストリーミングでの通知受信処理,stream_event_handlerへ代入
-void stream_event_notify(sjson_node *jobj_from_string)
+static void stream_event_notify(sjson_node *jobj_from_string)
 {
 	struct sjson_node *notify_type, *screen_name, *display_name, *status;
 	const char *dname;
@@ -166,7 +166,7 @@ void stream_event_notify(sjson_node *jobj_from_string)
 
 // ストリーミングでのToot受信処理,stream_event_handlerへ代入
 #define DATEBUFLEN	40
-void stream_event_update(struct sjson_node *jobj_from_string)
+static void stream_event_update(struct sjson_node *jobj_from_string)
 {
 	struct sjson_node *content, *screen_name, *display_name, *reblog, *visibility;
 	const char *sname, *dname, *vstr;
@@ -553,7 +553,7 @@ static void *prompt_thread_func(void *param)
 }
 
 // インスタンスにクライアントを登録する
-void do_create_client(char *domain, char *dot_ckcs)
+static void do_create_client(char *domain, char *dot_ckcs)
 {
 	CURLcode ret;
 	CURL *hnd;
@@ -606,7 +606,7 @@ void do_create_client(char *domain, char *dot_ckcs)
 }
 
 // 承認コードを使ったOAuth処理
-void do_oauth(char *code, char *ck, char *cs)
+static void do_oauth(char *code, char *ck, char *cs)
 {
 	char fields[512];
 	sprintf(fields, "client_id=%s&client_secret=%s&grant_type=authorization_code&code=%s&scope=read%%20write%%20follow", ck, cs, code);
@@ -664,7 +664,7 @@ void do_oauth(char *code, char *ck, char *cs)
 }
 
 // Tootを行う
-void do_toot(char *s)
+static void do_toot(char *s)
 {
 	CURLcode ret;
 	CURL *hnd;
@@ -754,7 +754,7 @@ static size_t htl_callback(void* ptr, size_t size, size_t nmemb, void* data) {
 }
 
 // Timelineの受信
-void get_timeline(void)
+static void get_timeline(void)
 {
 	CURLcode ret;
 	CURL *hnd;

--- a/nanotodon.c
+++ b/nanotodon.c
@@ -48,7 +48,7 @@ static void do_create_client(char *, char *);
 static void get_timeline(void);
 
 // 承認コードを使ったOAuth処理
-static void do_oauth(char *code, char *ck, char *cs);
+static void do_oauth(char *, char *, char *);
 
 // Tootを行う
 static void do_toot(char *);

--- a/nanotodon.h
+++ b/nanotodon.h
@@ -3,5 +3,6 @@
 
 extern int monoflag;
 extern char domain_string[256];
+extern struct nanotodon_config config;
 
 #endif

--- a/sbuf.h
+++ b/sbuf.h
@@ -12,12 +12,12 @@ typedef struct {
 #define COLOR_PAIR(n) (n)
 #define A_BOLD 0x80
 
-void ninitbuf(sbctx_t *sbctx);
-void nflushcache(sbctx_t *sbctx);
-void nputbuf(sbctx_t *sbctx, const void *d, int l);
-void nattron(sbctx_t *sbctx, int n);
-void nattroff(sbctx_t *sbctx, int n);
-void naddch(sbctx_t *sbctx, char c);
-void naddstr(sbctx_t *sbctx, const char *s);
+void ninitbuf(sbctx_t *);
+void nflushcache(sbctx_t *);
+void nputbuf(sbctx_t *, const void *, int);
+void nattron(sbctx_t *, int);
+void nattroff(sbctx_t *, int);
+void naddch(sbctx_t *, char);
+void naddstr(sbctx_t *, const char *);
 
 #endif

--- a/sixel.c
+++ b/sixel.c
@@ -38,11 +38,11 @@ static int indent_icon;
 #define CLIP_CH(n) ((n) > 255 ? 255 : (n) < 0 ? 0 : (n))
 
 #ifdef USE_WEBP
-static stbi_uc *webp_load_from_memory(stbi_uc const *buffer, int len, int *x, int *y, int *comp, int req_comp);
+static stbi_uc *webp_load_from_memory(stbi_uc const *, int, int *, int *, int *, int);
 #endif
-static void sixel_out(sbctx_t *sbctx, int ix, int iy, int ic, stbi_uc *ib, int mul);
-static uint32_t crc32b(const uint8_t *d, int maxlen);
-static void generate_hash(const char *uri, char *out);
+static void sixel_out(sbctx_t *, int, int, int, stbi_uc *, int);
+static uint32_t crc32b(const uint8_t *, int);
+static void generate_hash(const char *, char *);
 
 void sixel_init(void)
 {

--- a/sixel.h
+++ b/sixel.h
@@ -6,8 +6,8 @@
 #define SIXEL_MUL_PIC 48
 #define SIXEL_MUL_ICO 8
 
-void print_picture(sbctx_t *sbctx, char *uri, int mul);
-void move_cursor_to_avatar(sbctx_t *sbctx);
+void print_picture(sbctx_t *, char *, int);
+void move_cursor_to_avatar(sbctx_t *);
 void sixel_init(void);
 
 #endif

--- a/squeue.c
+++ b/squeue.c
@@ -1,9 +1,9 @@
 #include "squeue.h"
 
-sbctx_t queue_data[QUEUE_SIZE];
-pthread_mutex_t queue_mutex;
-int queue_head;
-int queue_num;
+static sbctx_t queue_data[QUEUE_SIZE];
+static pthread_mutex_t queue_mutex;
+static int queue_head;
+static int queue_num;
 
 void squeue_init(void)
 {

--- a/squeue.h
+++ b/squeue.h
@@ -7,7 +7,7 @@
 #define QUEUE_SIZE 512
 
 void squeue_init(void);
-int squeue_enqueue(sbctx_t enq_data);
-int squeue_dequeue(sbctx_t *deq_data);
+int squeue_enqueue(sbctx_t);
+int squeue_dequeue(sbctx_t *);
 
 #endif

--- a/utils.c
+++ b/utils.c
@@ -69,14 +69,14 @@ void curl_fatal(CURLcode ret, const char *errbuf)
 }
 
 // domain_stringとapiエンドポイントを合成してURLを生成する
-char *create_uri_string(char *api)
+char *create_uri_string(const char *api)
 {
 	char *s = malloc(256);
 	sprintf(s, "https://%s/%s", domain_string, api);
 	return s;
 }
 
-sjson_node *read_json_from_file(char *path, char **json_p, sjson_context **ctx_p)
+sjson_node *read_json_from_file(const char *path, char **json_p, sjson_context **ctx_p)
 {
 	char *json;
 	FILE *f = fopen(path, "rb");
@@ -102,7 +102,7 @@ sjson_node *read_json_from_file(char *path, char **json_p, sjson_context **ctx_p
 }
 
 // jsonツリーをパス形式(ex. "account/display_name")で掘ってjson_objectを取り出す
-int read_json_fom_path(struct sjson_node *obj, char *path, struct sjson_node **dst)
+int read_json_fom_path(struct sjson_node *obj, const char *path, struct sjson_node **dst)
 {
 	char *dup = strdup(path);	// strtokは破壊するので複製
 	struct sjson_node *dir = obj;

--- a/utils.h
+++ b/utils.h
@@ -5,14 +5,14 @@
 #include <stdint.h>
 #include "sjson.h"
 
-int ustrwidth(const char *str);
+int ustrwidth(const char *);
 
-void curl_fatal(CURLcode ret, const char *errbuf);
+void curl_fatal(CURLcode, const char *);
 
-char *create_uri_string(const char *api);
+char *create_uri_string(const char *);
 
-sjson_node *read_json_from_file(const char *path, char **json_p, sjson_context **ctx_p);
-int read_json_fom_path(struct sjson_node *obj, const char *path, struct sjson_node **dst);
+sjson_node *read_json_from_file(const char *, char **, sjson_context **);
+int read_json_fom_path(struct sjson_node *, const char *, struct sjson_node **);
 
 
 struct rawBuffer {
@@ -20,6 +20,6 @@ struct rawBuffer {
 	int data_size;
 };
 
-size_t buffer_writer(char *ptr, size_t size, size_t nmemb, void *stream);
+size_t buffer_writer(char *, size_t, size_t, void *);
 
 #endif

--- a/utils.h
+++ b/utils.h
@@ -9,10 +9,10 @@ int ustrwidth(const char *str);
 
 void curl_fatal(CURLcode ret, const char *errbuf);
 
-char *create_uri_string(char *api);
+char *create_uri_string(const char *api);
 
-sjson_node *read_json_from_file(char *path, char **json_p, sjson_context **ctx_p);
-int read_json_fom_path(struct sjson_node *obj, char *path, struct sjson_node **dst);
+sjson_node *read_json_from_file(const char *path, char **json_p, sjson_context **ctx_p);
+int read_json_fom_path(struct sjson_node *obj, const char *path, struct sjson_node **dst);
 
 
 struct rawBuffer {


### PR DESCRIPTION
最近静的解析ばかりやってるので目視で気づいたところだけなんとなく修正。
（何かをやった気になるためのコード盆栽ともいう）

* `*.c` で宣言されている関数はローカル扱いで `static` 付与
* ざっと見て変更されない引数は `const` 付与
* 関数プロトタイプから変数名を削除
（これはスタイル定義からですが、ありなし混在してたので）
* プロトタイプについて `char* var` と `char *var` が混在してたところは後者に統一
（これもスタイル定義からですが、後者が多数派っぽいので）

`static` と `const` は inline とかの最適化で効果あるはず、というやつですが計測はしてません。

`hidlckflag` と `noemojiflag` は `monoflag` と同列で export じゃないの、という説もありますが
現状 `nanotodon.h` には無いのと、`monoflag` についてもグローバルにせず
`sixel_init()` と `sixel_out()` (とそれを呼び出している `print_picture()`) の引数で
`mono` か否かを指定すればいいのでは、とか考え出すと止まらないので機械的に `static` にしています。

あと、 `-Wall` だと以下の警告も出ているようですが、意図が把握できていないのでここではいじっていません。
```
sixel.c: In function 'sixel_out':
sixel.c:323:11: warning: unused variable 'delta' [-Wunused-variable]
  323 |  uint32_t delta = mul & 0x100 ? 4 : 1;
```